### PR TITLE
boost: Honoring tools.build:defines

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1336,6 +1336,11 @@ class BoostConan(ConanFile):
         ldflags = " ".join(self.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)) + " "
         asflags = buildenv_vars.get("ASFLAGS", "") + " "
 
+        defines = " ".join(f"-D{d}" for d in self.conf.get("tools.build:defines", default=[], check_type=list)) + " "
+        if defines.strip():
+            cflags += defines
+            cxxflags += defines
+
         sysroot = self.conf.get("tools.build:sysroot")
         if sysroot and not is_msvc(self):
             sysroot = sysroot.replace("\\", "/")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1072,6 +1072,8 @@ class BoostConan(ConanFile):
         def add_defines(library):
             for define in self.dependencies[library].cpp_info.aggregated_components().defines:
                 flags.append(f"define={define}")
+            for define in self.conf.get("tools.build:defines", default=[], check_type=list):
+                flags.append(f"define={define.strip()}")
 
         if self._with_zlib:
             add_defines("zlib")
@@ -1335,11 +1337,6 @@ class BoostConan(ConanFile):
         cppflags = buildenv_vars.get("CPPFLAGS", "") + " "
         ldflags = " ".join(self.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)) + " "
         asflags = buildenv_vars.get("ASFLAGS", "") + " "
-
-        defines = " ".join(f"-D{d}" for d in self.conf.get("tools.build:defines", default=[], check_type=list)) + " "
-        if defines.strip():
-            cflags += defines
-            cxxflags += defines
 
         sysroot = self.conf.get("tools.build:sysroot")
         if sysroot and not is_msvc(self):


### PR DESCRIPTION
This PR uses the defines feature from b2 to pass compiler definitions listed in the Conan config.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
